### PR TITLE
Fix no_std support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! assert_eq!(&s[n..], "foo");
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 #![allow(
     clippy::cast_possible_truncation,


### PR DESCRIPTION
The crate does not set `no_std` even if you disable the `std` feature, so it can't be used in a `no_std` environment. A quick one-line fix and we're back in shape 😄